### PR TITLE
Added block explorers

### DIFF
--- a/lib/models/w3m_chain_info.dart
+++ b/lib/models/w3m_chain_info.dart
@@ -16,12 +16,15 @@ class W3MChainInfo with _$W3MChainInfo {
     required Map<String, RequiredNamespace> requiredNamespaces,
     required Map<String, RequiredNamespace> optionalNamespaces,
     required String rpcUrl,
+    BlockExplorer? blockExplorer,
     @Default(EVMService()) ILedgerService ledgerService,
   }) = _W3MChainInfo;
 }
 
-class W3MAssetIcon {
-  final String icon;
-
-  const W3MAssetIcon(this.icon);
+@freezed
+class BlockExplorer with _$BlockExplorer {
+  factory BlockExplorer({
+    required String name,
+    required String url,
+  }) = _BlockExplorer;
 }

--- a/lib/models/w3m_chain_info.freezed.dart
+++ b/lib/models/w3m_chain_info.freezed.dart
@@ -26,6 +26,7 @@ mixin _$W3MChainInfo {
   Map<String, RequiredNamespace> get optionalNamespaces =>
       throw _privateConstructorUsedError;
   String get rpcUrl => throw _privateConstructorUsedError;
+  BlockExplorer? get blockExplorer => throw _privateConstructorUsedError;
   ILedgerService get ledgerService => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
@@ -48,7 +49,10 @@ abstract class $W3MChainInfoCopyWith<$Res> {
       Map<String, RequiredNamespace> requiredNamespaces,
       Map<String, RequiredNamespace> optionalNamespaces,
       String rpcUrl,
+      BlockExplorer? blockExplorer,
       ILedgerService ledgerService});
+
+  $BlockExplorerCopyWith<$Res>? get blockExplorer;
 }
 
 /// @nodoc
@@ -72,6 +76,7 @@ class _$W3MChainInfoCopyWithImpl<$Res, $Val extends W3MChainInfo>
     Object? requiredNamespaces = null,
     Object? optionalNamespaces = null,
     Object? rpcUrl = null,
+    Object? blockExplorer = freezed,
     Object? ledgerService = null,
   }) {
     return _then(_value.copyWith(
@@ -107,11 +112,27 @@ class _$W3MChainInfoCopyWithImpl<$Res, $Val extends W3MChainInfo>
           ? _value.rpcUrl
           : rpcUrl // ignore: cast_nullable_to_non_nullable
               as String,
+      blockExplorer: freezed == blockExplorer
+          ? _value.blockExplorer
+          : blockExplorer // ignore: cast_nullable_to_non_nullable
+              as BlockExplorer?,
       ledgerService: null == ledgerService
           ? _value.ledgerService
           : ledgerService // ignore: cast_nullable_to_non_nullable
               as ILedgerService,
     ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $BlockExplorerCopyWith<$Res>? get blockExplorer {
+    if (_value.blockExplorer == null) {
+      return null;
+    }
+
+    return $BlockExplorerCopyWith<$Res>(_value.blockExplorer!, (value) {
+      return _then(_value.copyWith(blockExplorer: value) as $Val);
+    });
   }
 }
 
@@ -132,7 +153,11 @@ abstract class _$$_W3MChainInfoCopyWith<$Res>
       Map<String, RequiredNamespace> requiredNamespaces,
       Map<String, RequiredNamespace> optionalNamespaces,
       String rpcUrl,
+      BlockExplorer? blockExplorer,
       ILedgerService ledgerService});
+
+  @override
+  $BlockExplorerCopyWith<$Res>? get blockExplorer;
 }
 
 /// @nodoc
@@ -154,6 +179,7 @@ class __$$_W3MChainInfoCopyWithImpl<$Res>
     Object? requiredNamespaces = null,
     Object? optionalNamespaces = null,
     Object? rpcUrl = null,
+    Object? blockExplorer = freezed,
     Object? ledgerService = null,
   }) {
     return _then(_$_W3MChainInfo(
@@ -189,6 +215,10 @@ class __$$_W3MChainInfoCopyWithImpl<$Res>
           ? _value.rpcUrl
           : rpcUrl // ignore: cast_nullable_to_non_nullable
               as String,
+      blockExplorer: freezed == blockExplorer
+          ? _value.blockExplorer
+          : blockExplorer // ignore: cast_nullable_to_non_nullable
+              as BlockExplorer?,
       ledgerService: null == ledgerService
           ? _value.ledgerService
           : ledgerService // ignore: cast_nullable_to_non_nullable
@@ -209,6 +239,7 @@ class _$_W3MChainInfo implements _W3MChainInfo {
       required final Map<String, RequiredNamespace> requiredNamespaces,
       required final Map<String, RequiredNamespace> optionalNamespaces,
       required this.rpcUrl,
+      this.blockExplorer,
       this.ledgerService = const EVMService()})
       : _requiredNamespaces = requiredNamespaces,
         _optionalNamespaces = optionalNamespaces;
@@ -244,12 +275,14 @@ class _$_W3MChainInfo implements _W3MChainInfo {
   @override
   final String rpcUrl;
   @override
+  final BlockExplorer? blockExplorer;
+  @override
   @JsonKey()
   final ILedgerService ledgerService;
 
   @override
   String toString() {
-    return 'W3MChainInfo(chainName: $chainName, chainId: $chainId, namespace: $namespace, chainIcon: $chainIcon, tokenName: $tokenName, requiredNamespaces: $requiredNamespaces, optionalNamespaces: $optionalNamespaces, rpcUrl: $rpcUrl, ledgerService: $ledgerService)';
+    return 'W3MChainInfo(chainName: $chainName, chainId: $chainId, namespace: $namespace, chainIcon: $chainIcon, tokenName: $tokenName, requiredNamespaces: $requiredNamespaces, optionalNamespaces: $optionalNamespaces, rpcUrl: $rpcUrl, blockExplorer: $blockExplorer, ledgerService: $ledgerService)';
   }
 
   @override
@@ -271,6 +304,8 @@ class _$_W3MChainInfo implements _W3MChainInfo {
             const DeepCollectionEquality()
                 .equals(other._optionalNamespaces, _optionalNamespaces) &&
             (identical(other.rpcUrl, rpcUrl) || other.rpcUrl == rpcUrl) &&
+            (identical(other.blockExplorer, blockExplorer) ||
+                other.blockExplorer == blockExplorer) &&
             (identical(other.ledgerService, ledgerService) ||
                 other.ledgerService == ledgerService));
   }
@@ -286,6 +321,7 @@ class _$_W3MChainInfo implements _W3MChainInfo {
       const DeepCollectionEquality().hash(_requiredNamespaces),
       const DeepCollectionEquality().hash(_optionalNamespaces),
       rpcUrl,
+      blockExplorer,
       ledgerService);
 
   @JsonKey(ignore: true)
@@ -305,6 +341,7 @@ abstract class _W3MChainInfo implements W3MChainInfo {
       required final Map<String, RequiredNamespace> requiredNamespaces,
       required final Map<String, RequiredNamespace> optionalNamespaces,
       required final String rpcUrl,
+      final BlockExplorer? blockExplorer,
       final ILedgerService ledgerService}) = _$_W3MChainInfo;
 
   @override
@@ -324,9 +361,146 @@ abstract class _W3MChainInfo implements W3MChainInfo {
   @override
   String get rpcUrl;
   @override
+  BlockExplorer? get blockExplorer;
+  @override
   ILedgerService get ledgerService;
   @override
   @JsonKey(ignore: true)
   _$$_W3MChainInfoCopyWith<_$_W3MChainInfo> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$BlockExplorer {
+  String get name => throw _privateConstructorUsedError;
+  String get url => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $BlockExplorerCopyWith<BlockExplorer> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $BlockExplorerCopyWith<$Res> {
+  factory $BlockExplorerCopyWith(
+          BlockExplorer value, $Res Function(BlockExplorer) then) =
+      _$BlockExplorerCopyWithImpl<$Res, BlockExplorer>;
+  @useResult
+  $Res call({String name, String url});
+}
+
+/// @nodoc
+class _$BlockExplorerCopyWithImpl<$Res, $Val extends BlockExplorer>
+    implements $BlockExplorerCopyWith<$Res> {
+  _$BlockExplorerCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? url = null,
+  }) {
+    return _then(_value.copyWith(
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      url: null == url
+          ? _value.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_BlockExplorerCopyWith<$Res>
+    implements $BlockExplorerCopyWith<$Res> {
+  factory _$$_BlockExplorerCopyWith(
+          _$_BlockExplorer value, $Res Function(_$_BlockExplorer) then) =
+      __$$_BlockExplorerCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String name, String url});
+}
+
+/// @nodoc
+class __$$_BlockExplorerCopyWithImpl<$Res>
+    extends _$BlockExplorerCopyWithImpl<$Res, _$_BlockExplorer>
+    implements _$$_BlockExplorerCopyWith<$Res> {
+  __$$_BlockExplorerCopyWithImpl(
+      _$_BlockExplorer _value, $Res Function(_$_BlockExplorer) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? url = null,
+  }) {
+    return _then(_$_BlockExplorer(
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      url: null == url
+          ? _value.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_BlockExplorer implements _BlockExplorer {
+  _$_BlockExplorer({required this.name, required this.url});
+
+  @override
+  final String name;
+  @override
+  final String url;
+
+  @override
+  String toString() {
+    return 'BlockExplorer(name: $name, url: $url)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_BlockExplorer &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.url, url) || other.url == url));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, name, url);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_BlockExplorerCopyWith<_$_BlockExplorer> get copyWith =>
+      __$$_BlockExplorerCopyWithImpl<_$_BlockExplorer>(this, _$identity);
+}
+
+abstract class _BlockExplorer implements BlockExplorer {
+  factory _BlockExplorer(
+      {required final String name,
+      required final String url}) = _$_BlockExplorer;
+
+  @override
+  String get name;
+  @override
+  String get url;
+  @override
+  @JsonKey(ignore: true)
+  _$$_BlockExplorerCopyWith<_$_BlockExplorer> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/pages/account_page.dart
+++ b/lib/pages/account_page.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 
 import 'package:web3modal_flutter/constants/constants.dart';
 import 'package:web3modal_flutter/pages/select_network_page.dart';
-import 'package:web3modal_flutter/theme/theme.dart';
 import 'package:web3modal_flutter/utils/widget_stack/widget_stack_singleton.dart';
+import 'package:web3modal_flutter/web3modal_flutter.dart';
 import 'package:web3modal_flutter/widgets/web3modal_provider.dart';
 import 'package:web3modal_flutter/widgets/avatars/w3m_account_orb.dart';
 import 'package:web3modal_flutter/widgets/buttons/address_copy_button.dart';
@@ -36,21 +36,23 @@ class AccountPage extends StatelessWidget {
                     const SizedBox.square(dimension: 12.0),
                     const W3MAddressWithCopyButton(),
                     const W3MBalanceText(),
-                    const SizedBox.square(dimension: 12.0),
-                    SimpleIconButton(
-                      onTap: () {
-                        // TODO implement
-                        debugPrint('Block Explorer');
-                      },
-                      leftIcon: 'assets/icons/compass.svg',
-                      rightIcon: 'assets/icons/arrow_top_right.svg',
-                      title: 'Block Explorer',
-                      backgroundColor: themeData.colors.background125,
-                      foregroundColor: themeData.colors.foreground150,
-                      overlayColor: MaterialStateProperty.all<Color>(
-                        themeData.colors.background200,
+                    if (service.hasBlockExplorer)
+                      Column(
+                        children: [
+                          const SizedBox.square(dimension: 12.0),
+                          SimpleIconButton(
+                            onTap: () => service.launchBlockExplorer(),
+                            leftIcon: 'assets/icons/compass.svg',
+                            rightIcon: 'assets/icons/arrow_top_right.svg',
+                            title: 'Block Explorer',
+                            backgroundColor: themeData.colors.background125,
+                            foregroundColor: themeData.colors.foreground150,
+                            overlayColor: MaterialStateProperty.all<Color>(
+                              themeData.colors.background200,
+                            ),
+                          ),
+                        ],
                       ),
-                    ),
                   ],
                 ),
                 const SizedBox.square(dimension: 20.0),
@@ -64,8 +66,8 @@ class AccountPage extends StatelessWidget {
                     title: service.selectedChain?.chainName ?? '',
                     onTap: () {
                       widgetStack.instance.add(SelectNetworkPage(
-                        onTapNetwork: (chainInfo) {
-                          // TODO check what happens when switch can not be done
+                        onTapNetwork: (W3MChainInfo chainInfo) {
+                          // TODO FOCUS 2 check what happens when switch can not be done
                           service.setSelectedChain(
                             chainInfo,
                             switchChain: true,

--- a/lib/pages/qr_code_page.dart
+++ b/lib/pages/qr_code_page.dart
@@ -15,6 +15,7 @@ import 'package:walletconnect_modal_flutter/services/utils/platform/platform_uti
 import 'package:walletconnect_modal_flutter/services/utils/toast/toast_message.dart';
 import 'package:walletconnect_modal_flutter/services/utils/toast/toast_utils_singleton.dart';
 
+// TODO FOCUS 4 better QR code
 class QRCodePage extends StatelessWidget {
   const QRCodePage() : super(key: Web3ModalKeyConstants.qrCodePageKey);
 

--- a/lib/services/w3m_service/i_w3m_service.dart
+++ b/lib/services/w3m_service/i_w3m_service.dart
@@ -43,4 +43,8 @@ abstract class IW3MService extends IWalletConnectModalService
 
   WalletData? get selectedWallet;
   void selectWallet({required WalletData? walletData});
+
+  bool get hasBlockExplorer;
+
+  void launchBlockExplorer();
 }

--- a/lib/services/w3m_service/w3m_service.dart
+++ b/lib/services/w3m_service/w3m_service.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'package:walletconnect_modal_flutter/models/listings.dart';
+import 'package:walletconnect_modal_flutter/services/utils/url/url_utils_singleton.dart';
 
 import 'package:web3modal_flutter/utils/widget_stack/widget_stack_singleton.dart';
 import 'package:web3modal_flutter/models/w3m_chain_info.dart';
@@ -191,9 +193,7 @@ class W3MService extends WalletConnectModalService implements IW3MService {
 
     // Set the requiredNamespace to be the selected chain
     // This will also notify listeners
-    setRequiredNamespaces(
-      requiredNamespaces: chain.requiredNamespaces,
-    );
+    setRequiredNamespaces(requiredNamespaces: chain.requiredNamespaces);
 
     // Load the account data, notify listeners when done
     await _loadAccountData(closeModal: !switchChain);
@@ -412,5 +412,20 @@ class W3MService extends WalletConnectModalService implements IW3MService {
   @override
   void selectWallet({required WalletData? walletData}) {
     _walletData = walletData;
+  }
+
+  @override
+  bool get hasBlockExplorer => _selectedChain?.blockExplorer != null;
+
+  @override
+  void launchBlockExplorer() async {
+    if (hasBlockExplorer) {
+      final blockExplorer = _selectedChain!.blockExplorer!.url;
+      final explorerUrl = '$blockExplorer/address/$address';
+      await urlUtils.instance.launchUrl(
+        Uri.parse(explorerUrl),
+        mode: LaunchMode.externalApplication,
+      );
+    }
   }
 }

--- a/lib/utils/asset_util.dart
+++ b/lib/utils/asset_util.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:collection/collection.dart';
+
 import 'package:web3modal_flutter/theme/theme.dart';
 import 'package:web3modal_flutter/utils/chain_data.dart';
 
@@ -9,7 +11,9 @@ class AssetUtil {
   }
 
   static String getTokenIconAssetId(String tokenName) {
-    return ChainData.tokenPresets[tokenName]?.icon ??
+    return ChainData.chainPresets.values
+            .firstWhereOrNull((element) => element.tokenName == tokenName)
+            ?.chainIcon ??
         '692ed6ba-e569-459a-556a-776476829e00';
   }
 

--- a/lib/utils/chain_data.dart
+++ b/lib/utils/chain_data.dart
@@ -26,6 +26,10 @@ class ChainData {
         ),
       },
       rpcUrl: 'https://eth.drpc.org',
+      blockExplorer: BlockExplorer(
+        name: 'Etherscan',
+        url: 'https://etherscan.io',
+      ),
     ),
     '42161': W3MChainInfo(
       chainName: 'Arbitrum',
@@ -48,6 +52,10 @@ class ChainData {
         ),
       },
       rpcUrl: 'https://arbitrum.blockpi.network/v1/rpc/public',
+      blockExplorer: BlockExplorer(
+        name: 'Arbiscan',
+        url: 'https://arbiscan.io/',
+      ),
     ),
     '137': W3MChainInfo(
       chainName: 'Polygon',
@@ -70,6 +78,10 @@ class ChainData {
         ),
       },
       rpcUrl: 'https://polygon.drpc.org',
+      blockExplorer: BlockExplorer(
+        name: 'Explorer',
+        url: 'https://explorer.matic.network/',
+      ),
     ),
     '43114': W3MChainInfo(
       chainName: 'Avalanche',
@@ -92,6 +104,10 @@ class ChainData {
         ),
       },
       rpcUrl: 'https://api.avax.network/ext/bc/C/rpc',
+      blockExplorer: BlockExplorer(
+        name: 'Snowtrace',
+        url: 'https://snowtrace.io',
+      ),
     ),
     '56': W3MChainInfo(
       chainName: 'Binance Smart Chain',
@@ -114,6 +130,10 @@ class ChainData {
         ),
       },
       rpcUrl: 'https://bsc-dataseed.binance.org/',
+      blockExplorer: BlockExplorer(
+        name: 'BSC Scan',
+        url: 'https://bscscan.com',
+      ),
     ),
     '10': W3MChainInfo(
       chainName: 'Optimism',
@@ -158,6 +178,10 @@ class ChainData {
         ),
       },
       rpcUrl: 'https://rpc.ftm.tools/',
+      blockExplorer: BlockExplorer(
+        name: 'FTM Scan',
+        url: 'https://ftmscan.com',
+      ),
     ),
     '9001': W3MChainInfo(
       chainName: 'EVMos',
@@ -202,6 +226,10 @@ class ChainData {
         ),
       },
       rpcUrl: 'https://rpc.ankr.com/iotex',
+      blockExplorer: BlockExplorer(
+        name: 'IOTEX Scan',
+        url: 'https://iotexscan.io/',
+      ),
     ),
     '1088': W3MChainInfo(
       chainName: 'Metis',
@@ -255,19 +283,5 @@ class ChainData {
     //   chainIcon: 'f1d73bb6-5450-4e18-38f7-fb6484264a00',
     //   tokenName: 'ETH',
     // ),
-  };
-
-  static const Map<String, W3MAssetIcon> tokenPresets = {
-    'ETH': W3MAssetIcon('692ed6ba-e569-459a-556a-776476829e00'),
-    'WETH': W3MAssetIcon('692ed6ba-e569-459a-556a-776476829e00'),
-    'AVAX': W3MAssetIcon('30c46e53-e989-45fb-4549-be3bd4eb3b00'),
-    'FTM': W3MAssetIcon('06b26297-fe0c-4733-5d6b-ffa5498aac00'),
-    'BNB': W3MAssetIcon('93564157-2e8e-4ce7-81df-b264dbee9b00'),
-    'MATIC': W3MAssetIcon('41d04d42-da3b-4453-8506-668cc0727900'),
-    'OP': W3MAssetIcon('ab9c186a-c52f-464b-2906-ca59d760a400'),
-    'xDAI': W3MAssetIcon('02b53f6a-e3d4-479e-1cb4-21178987d100'),
-    'EVMOS': W3MAssetIcon('f926ff41-260d-4028-635e-91913fc28e00'),
-    'METIS': W3MAssetIcon('3897a66d-40b9-4833-162f-a2c90531c900'),
-    'IOTX': W3MAssetIcon('34e68754-e536-40da-c153-6ef2e7188a00'),
   };
 }

--- a/lib/utils/widget_stack/transition_container.dart
+++ b/lib/utils/widget_stack/transition_container.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+// TODO FOCUS 3 change transition
 class TransitionContainer extends StatefulWidget {
   const TransitionContainer({
     super.key,

--- a/lib/widgets/lists/networks_grid.dart
+++ b/lib/widgets/lists/networks_grid.dart
@@ -7,6 +7,7 @@ import 'package:web3modal_flutter/widgets/lists/grid_items/wallet_grid_item.dart
 
 import 'package:walletconnect_modal_flutter/widgets/grid_list/grid_list_item_model.dart';
 
+// TODO FOCUS 5 landscape support
 class NetworksGrid extends StatelessWidget {
   const NetworksGrid({
     super.key,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -170,7 +170,7 @@ packages:
     source: hosted
     version: "4.6.0"
   collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: collection
       sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: '>=2.17.0 <4.0.0'
 
 dependencies:
+  collection: ^1.17.2
   cupertino_icons: ^1.0.2
   flex_color_picker: ^3.2.2
   flutter:


### PR DESCRIPTION
**Context:**

Currently Web3ModalFlutter relies heavily on WalletConnectModalFlutter package. We want to change that and completely decouple them both.

Since Web3ModalFlutter is going to be restyled with v3 designs this is a first step towards that direction.

**Changes:**

- Added block explorer urls on chains presets and implement opening

_Note:_ The PR points to an intermediate branch called feat/v3restyle as I will be adding breaking changes and we don’t want to break anything for devs that may be using the package. Once everything is done we will merge the intermediate branch with master

**Final goal:**

- To have a completely independent Web3Modal package with it's own v3 design style