### PR TITLE
fix: use rootNavigator = true when close web3 modal

### DIFF
--- a/lib/services/w3m_service/w3m_service.dart
+++ b/lib/services/w3m_service/w3m_service.dart
@@ -589,7 +589,7 @@ class W3MService with ChangeNotifier, CoinbaseService implements IW3MService {
     if (_context != null) {
       // _isOpen and notify() are handled when we call Navigator.pop()
       // by the open() method
-      Navigator.pop(_context!);
+      Navigator.of(_context!, rootNavigator: true).pop();
     } else {
       _notify();
     }


### PR DESCRIPTION
# What ?
- use rootNavigator = true when close web3 modal

# Why ?
- Navigator.pop without using rootNavigator sometimes make the navigation system returns the blank screen

reference: https://stackoverflow.com/questions/53723294/flutter-navigator-popcontext-returning-a-black-screen