### PR TITLE
fix: deeplink url format

### DIFF
--- a/lib/utils/core/core_utils.dart
+++ b/lib/utils/core/core_utils.dart
@@ -83,6 +83,9 @@ class CoreUtils extends ICoreUtils {
     } else {
       final parts = safeUrl.split('://');
       if (parts.last.isNotEmpty && parts.last != 'wc') {
+        if (!safeUrl.endsWith('/')) {
+          return '$safeUrl/';
+        }
         return safeUrl;
       } else {
         safeUrl = url.replaceFirst('://wc', '://');
@@ -118,7 +121,7 @@ class CoreUtils extends ICoreUtils {
 
     final encodedWcUrl = Uri.encodeComponent(wcUri);
 
-    return Uri.parse('${safeAppUrl}/wc?uri=$encodedWcUrl');
+    return Uri.parse('${safeAppUrl}wc?uri=$encodedWcUrl');
   }
 
   @override

--- a/lib/utils/core/core_utils.dart
+++ b/lib/utils/core/core_utils.dart
@@ -118,7 +118,7 @@ class CoreUtils extends ICoreUtils {
 
     final encodedWcUrl = Uri.encodeComponent(wcUri);
 
-    return Uri.parse('${safeAppUrl}wc?uri=$encodedWcUrl');
+    return Uri.parse('${safeAppUrl}/wc?uri=$encodedWcUrl');
   }
 
   @override


### PR DESCRIPTION
### Description

We've received several reports of users unable to link to Valora using Web3ModalFlutter in [our discord](https://discord.com/channels/886972503560433675/887422238071087154).

After investigation it appears the URL format is missing an `/` character and parsing incorrectly. This should fix that integration and match the deeplinks created by other WalletConnect Web3Modal implementations.

Before: `celo://walletwc?uri=wc...`
After: `celo://wallet/wc?uri=wc...`