### PR TITLE
Chore: Refactor switch network logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.2
+
+- Network change improvements
+
 ## 3.2.1
 
 - Email Wallet improvements:

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
-versionName=3.2.1
-versionCode=59
+versionName=3.2.2
+versionCode=61

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -470,7 +470,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 59;
+				CURRENT_PROJECT_VERSION = 61;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = W5R8AG9K22;
 				ENABLE_BITCODE = NO;
@@ -496,7 +496,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 59;
+				CURRENT_PROJECT_VERSION = 61;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.web3modal.flutterExample.RunnerTests;
@@ -514,7 +514,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 59;
+				CURRENT_PROJECT_VERSION = 61;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.web3modal.flutterExample.RunnerTests;
@@ -530,7 +530,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 59;
+				CURRENT_PROJECT_VERSION = 61;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.web3modal.flutterExample.RunnerTests;
@@ -655,7 +655,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 59;
+				CURRENT_PROJECT_VERSION = 61;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = W5R8AG9K22;
 				ENABLE_BITCODE = NO;
@@ -686,7 +686,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 59;
+				CURRENT_PROJECT_VERSION = 61;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = W5R8AG9K22;
 				ENABLE_BITCODE = NO;

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.1</string>
+	<string>3.2.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>59</string>
+	<string>61</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/example/lib/home_page.dart
+++ b/example/lib/home_page.dart
@@ -171,13 +171,13 @@ class _MyHomePageState extends State<MyHomePage> {
                 ElevatedButton(
                   onPressed: () async {
                     _w3mService.launchConnectedWallet();
-                    _w3mService.requestAddChain(polygon).then(
-                      (value) {
-                        final success = value == true;
-                        debugPrint('[ExampleApp] then success $success');
-                        Navigator.of(context).pop();
-                      },
-                    );
+                    try {
+                      await _w3mService.requestSwitchToChain(polygon);
+                    } catch (e) {
+                      debugPrint('[ExampleApp] requestSwitchToChain $e');
+                    }
+                    // ignore: use_build_context_synchronously
+                    Navigator.of(context).pop();
                   },
                   child: const Text('Switch'),
                 ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -1139,7 +1139,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.2.1"
+    version: "3.2.2"
   web_socket_channel:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: A dApp showing how to use WalletConnect v2 with Flutter
 
 publish_to: "none"
 
-version: 3.2.1
+version: 3.2.2
 
 environment:
   sdk: ">=3.0.1 <4.0.0"

--- a/lib/pages/select_network_page.dart
+++ b/lib/pages/select_network_page.dart
@@ -22,17 +22,15 @@ class SelectNetworkPage extends StatelessWidget {
 
   final Function(W3MChainInfo)? onTapNetwork;
 
-  void _onSelectNetwork(BuildContext context, W3MChainInfo chainInfo) {
+  void _onSelectNetwork(BuildContext context, W3MChainInfo chainInfo) async {
     final service = Web3ModalProvider.of(context).service;
     if (service.isConnected) {
       final approvedChains = service.session!.getApprovedChains() ?? [];
-      final hasChainAlready = approvedChains.contains(
-        chainInfo.namespace,
-      );
+      final isChainApproved = approvedChains.contains(chainInfo.namespace);
       if (chainInfo.chainId == service.selectedChain?.chainId) {
         widgetStack.instance.pop();
-      } else if (hasChainAlready || service.session!.sessionService.isMagic) {
-        service.selectChain(chainInfo, switchChain: true);
+      } else if (isChainApproved || service.session!.sessionService.isMagic) {
+        await service.selectChain(chainInfo, switchChain: true);
         widgetStack.instance.pop();
       } else {
         widgetStack.instance.push(ConnectNetworkPage(chainInfo: chainInfo));

--- a/lib/services/w3m_service/i_w3m_service.dart
+++ b/lib/services/w3m_service/i_w3m_service.dart
@@ -131,8 +131,8 @@ abstract class IW3MService with ChangeNotifier {
     required SessionRequestParams request,
   });
 
-  Future<dynamic> requestSwitchToChain(W3MChainInfo newChain);
-  Future<dynamic> requestAddChain(W3MChainInfo newChain);
+  Future<void> requestSwitchToChain(W3MChainInfo newChain);
+  Future<void> requestAddChain(W3MChainInfo newChain);
 
   /// Closes the modal.
   void closeModal();

--- a/lib/utils/w3m_chains_presets.dart
+++ b/lib/utils/w3m_chains_presets.dart
@@ -33,7 +33,12 @@ class W3MChainPresets {
       chainId: '137',
       chainIcon: chainImagesId['137'],
       tokenName: 'MATIC',
-      rpcUrl: 'https://rpc-mainnet.maticvigil.com',
+      rpcUrl: 'https://polygon-bor-rpc.publicnode.com',
+      extraRpcUrls: [
+        'https://polygon.drpc.org',
+        'https://1rpc.io/matic',
+        'https://endpoints.omniatech.io/v1/matic/mainnet/public',
+      ],
       blockExplorer: W3MBlockExplorer(
         name: 'Explorer',
         url: 'https://polygonscan.com',

--- a/lib/version.dart
+++ b/lib/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '3.2.1';
+const packageVersion = '3.2.2';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: web3modal_flutter
 description: "WalletConnect Web3Modal: Simple, intuitive wallet login. With this drop-in UI SDK, enable any wallet's users to seamlessly log in to your app and enjoy a unified experience"
-version: 3.2.1
+version: 3.2.2
 repository: https://github.com/WalletConnect/Web3ModalFlutter
 
 environment:

--- a/test/mock_classes.mocks.dart
+++ b/test/mock_classes.mocks.dart
@@ -870,23 +870,25 @@ class MockW3MService extends _i1.Mock implements _i3.W3MService {
         returnValueForMissingStub: _i14.Future<void>.value(),
       ) as _i14.Future<void>);
   @override
-  _i14.Future<dynamic> requestSwitchToChain(_i3.W3MChainInfo? newChain) =>
+  _i14.Future<void> requestSwitchToChain(_i3.W3MChainInfo? newChain) =>
       (super.noSuchMethod(
         Invocation.method(
           #requestSwitchToChain,
           [newChain],
         ),
-        returnValue: _i14.Future<dynamic>.value(),
-      ) as _i14.Future<dynamic>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
   @override
-  _i14.Future<dynamic> requestAddChain(_i3.W3MChainInfo? newChain) =>
+  _i14.Future<void> requestAddChain(_i3.W3MChainInfo? newChain) =>
       (super.noSuchMethod(
         Invocation.method(
           #requestAddChain,
           [newChain],
         ),
-        returnValue: _i14.Future<dynamic>.value(),
-      ) as _i14.Future<dynamic>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
   @override
   void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(


### PR DESCRIPTION
UX/UI shouldn't expect for `chainChanged` event to arrive to modify its state, rather it should just check whether `Future<void> requestSwitchToChain(W3MChainInfo newChain)` throws an error or not.

If no error is thrown and request completes successfully then Dapp should assume the switch was successful regardless of the `chainChanged` arriving or not.